### PR TITLE
Leverage support for Github Releases to download plugin binaries

### DIFF
--- a/provider/cmd/pulumi-resource-onepassword/schema.json
+++ b/provider/cmd/pulumi-resource-onepassword/schema.json
@@ -12,7 +12,7 @@
     "attribution": "This Pulumi package is based on the [`onepassword` Terraform Provider](https://github.com/1Password/terraform-provider-onepassword).",
     "repository": "https://github.com/SimCubeLtd/pulumi-onepassword",
     "logoUrl": "https://avatars.githubusercontent.com/u/38230737?s=200\u0026v=4",
-    "pluginDownloadURL": "https://github.com/SimCubeLtd/pulumi-onepassword/releases/download/v${VERSION}",
+    "pluginDownloadURL": "github://api.github.com/SimCubeLtd",
     "publisher": "SimCubeLtd",
     "meta": {
         "moduleFormat": "(.*)(?:/[^/]*)"

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -18,10 +18,10 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/1Password/terraform-provider-onepassword/onepassword"
+	"github.com/SimCubeLtd/pulumi-onepassword/provider/pkg/version"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
-	"github.com/SimCubeLtd/pulumi-onepassword/provider/pkg/version"
-	"github.com/1Password/terraform-provider-onepassword/onepassword"
 )
 
 const (
@@ -33,39 +33,39 @@ func Provider() tfbridge.ProviderInfo {
 	p := shimv2.NewProvider(onepassword.Provider())
 
 	prov := tfbridge.ProviderInfo{
-		P:    p,
-		Name: "onepassword",
-		DisplayName: "1Password",
-		Publisher: "SimCubeLtd",
-		LogoURL: "https://avatars.githubusercontent.com/u/38230737?s=200&v=4",
-		PluginDownloadURL: "https://github.com/SimCubeLtd/pulumi-onepassword/releases/download/v${VERSION}",
+		P:                 p,
+		Name:              "onepassword",
+		DisplayName:       "1Password",
+		Publisher:         "SimCubeLtd",
+		LogoURL:           "https://avatars.githubusercontent.com/u/38230737?s=200&v=4",
+		PluginDownloadURL: "github://api.github.com/SimCubeLtd",
 		Description:       "A Pulumi package for creating and managing onepassword resources.",
-		Keywords:   []string{"pulumi", "onepassword", "category/cloud"},
-		License:    "MIT",
-		Homepage:   "https://github.com/SimCubeLtd/pulumi-onepassword",
-		Repository: "https://github.com/SimCubeLtd/pulumi-onepassword",
-		GitHubOrg: "1Password",
-		Config:    map[string]*tfbridge.SchemaInfo{},
-		Resources:            map[string]*tfbridge.ResourceInfo{
-		    "onepassword_item": {
-		        Tok: tfbridge.MakeResource(mainPkg, mainMod, "Item"),
-		        Fields: map[string]*tfbridge.SchemaInfo{
-		            "password": {
-		                Secret: tfbridge.True(),
-		            },
-		        },
-		    },
+		Keywords:          []string{"pulumi", "onepassword", "category/cloud"},
+		License:           "MIT",
+		Homepage:          "https://github.com/SimCubeLtd/pulumi-onepassword",
+		Repository:        "https://github.com/SimCubeLtd/pulumi-onepassword",
+		GitHubOrg:         "1Password",
+		Config:            map[string]*tfbridge.SchemaInfo{},
+		Resources: map[string]*tfbridge.ResourceInfo{
+			"onepassword_item": {
+				Tok: tfbridge.MakeResource(mainPkg, mainMod, "Item"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"password": {
+						Secret: tfbridge.True(),
+					},
+				},
+			},
 		},
 		DataSources: map[string]*tfbridge.DataSourceInfo{
 			"onepassword_item": {
-			    Tok: tfbridge.MakeDataSource(mainPkg, mainMod, "GetItem"),
+				Tok: tfbridge.MakeDataSource(mainPkg, mainMod, "GetItem"),
 			},
 			"onepassword_vault": {
-  			    Tok: tfbridge.MakeDataSource(mainPkg, mainMod, "GetVault"),
-            },
+				Tok: tfbridge.MakeDataSource(mainPkg, mainMod, "GetVault"),
+			},
 		},
 		JavaScript: &tfbridge.JavaScriptInfo{
-		    PackageName: "@simcubeltd/pulumi-onepassword",
+			PackageName: "@simcubeltd/pulumi-onepassword",
 			Dependencies: map[string]string{
 				"@pulumi/pulumi": "^3.0.0",
 			},
@@ -75,7 +75,7 @@ func Provider() tfbridge.ProviderInfo {
 			},
 		},
 		Python: &tfbridge.PythonInfo{
-		    PackageName: "simcubeltd_pulumi_onepassword",
+			PackageName: "simcubeltd_pulumi_onepassword",
 			Requires: map[string]string{
 				"pulumi": ">=3.0.0,<4.0.0",
 			},

--- a/sdk/dotnet/Item.cs
+++ b/sdk/dotnet/Item.cs
@@ -174,7 +174,7 @@ namespace Pulumi.Onepassword
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
-                PluginDownloadURL = "https://github.com/SimCubeLtd/pulumi-onepassword/releases/download/v${VERSION}",
+                PluginDownloadURL = "github://api.github.com/SimCubeLtd",
                 AdditionalSecretOutputs =
                 {
                     "password",

--- a/sdk/dotnet/Provider.cs
+++ b/sdk/dotnet/Provider.cs
@@ -49,7 +49,7 @@ namespace Pulumi.Onepassword
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
-                PluginDownloadURL = "https://github.com/SimCubeLtd/pulumi-onepassword/releases/download/v${VERSION}",
+                PluginDownloadURL = "github://api.github.com/SimCubeLtd",
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/Utilities.cs
+++ b/sdk/dotnet/Utilities.cs
@@ -53,7 +53,7 @@ namespace Pulumi.Onepassword
         {
             var dst = src ?? new global::Pulumi.InvokeOptions{};
             dst.Version = src?.Version ?? Version;
-            dst.PluginDownloadURL = src?.PluginDownloadURL ?? "https://github.com/SimCubeLtd/pulumi-onepassword/releases/download/v${VERSION}";
+            dst.PluginDownloadURL = src?.PluginDownloadURL ?? "github://api.github.com/SimCubeLtd";
             return dst;
         }
 

--- a/sdk/dotnet/pulumi-plugin.json
+++ b/sdk/dotnet/pulumi-plugin.json
@@ -1,5 +1,5 @@
 {
   "resource": true,
   "name": "onepassword",
-  "server": "https://github.com/SimCubeLtd/pulumi-onepassword/releases/download/v${VERSION}"
+  "server": "github://api.github.com/SimCubeLtd"
 }

--- a/sdk/go/onepassword/doc.go
+++ b/sdk/go/onepassword/doc.go
@@ -1,3 +1,2 @@
 // A Pulumi package for creating and managing onepassword resources.
-//
 package onepassword

--- a/sdk/go/onepassword/getItem.go
+++ b/sdk/go/onepassword/getItem.go
@@ -18,23 +18,26 @@ import (
 // package main
 //
 // import (
-// 	"github.com/SimCubeLtd/pulumi-onepassword/sdk/go/onepassword"
-// 	"github.com/pulumi/pulumi-onepassword/sdk/go/onepassword"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/SimCubeLtd/pulumi-onepassword/sdk/go/onepassword"
+//	"github.com/pulumi/pulumi-onepassword/sdk/go/onepassword"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := onepassword.GetItem(ctx, &GetItemArgs{
-// 			Vault: _var.Demo_vault,
-// 			Uuid:  pulumi.StringRef(onepassword_item.Demo_sections.Uuid),
-// 		}, nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := onepassword.GetItem(ctx, &GetItemArgs{
+//				Vault: _var.Demo_vault,
+//				Uuid:  pulumi.StringRef(onepassword_item.Demo_sections.Uuid),
+//			}, nil)
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 func LookupItem(ctx *pulumi.Context, args *LookupItemArgs, opts ...pulumi.InvokeOption) (*LookupItemResult, error) {
 	opts = pkgInvokeDefaultOpts(opts)

--- a/sdk/go/onepassword/item.go
+++ b/sdk/go/onepassword/item.go
@@ -19,50 +19,53 @@ import (
 // package main
 //
 // import (
-// 	"github.com/SimCubeLtd/pulumi-onepassword/sdk/go/onepassword"
-// 	"github.com/pulumi/pulumi-onepassword/sdk/go/onepassword"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/SimCubeLtd/pulumi-onepassword/sdk/go/onepassword"
+//	"github.com/pulumi/pulumi-onepassword/sdk/go/onepassword"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := onepassword.NewItem(ctx, "demoPassword", &onepassword.ItemArgs{
-// 			Vault:    pulumi.Any(_var.Demo_vault),
-// 			Title:    pulumi.String("Demo Password Recipe"),
-// 			Category: pulumi.String("password"),
-// 			PasswordRecipe: &ItemPasswordRecipeArgs{
-// 				Length:  pulumi.Int(40),
-// 				Symbols: pulumi.Bool(false),
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = onepassword.NewItem(ctx, "demoLogin", &onepassword.ItemArgs{
-// 			Vault:    pulumi.Any(_var.Demo_vault),
-// 			Title:    pulumi.String("Demo Terraform Login"),
-// 			Category: pulumi.String("login"),
-// 			Username: pulumi.String("test@example.com"),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = onepassword.NewItem(ctx, "demoDb", &onepassword.ItemArgs{
-// 			Vault:    pulumi.Any(_var.Demo_vault),
-// 			Category: pulumi.String("database"),
-// 			Type:     pulumi.String("mysql"),
-// 			Title:    pulumi.String("Demo TF Database"),
-// 			Username: pulumi.String("root"),
-// 			Database: pulumi.String("Example MySQL Instance"),
-// 			Hostname: pulumi.String("localhost"),
-// 			Port:     pulumi.String("3306"),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := onepassword.NewItem(ctx, "demoPassword", &onepassword.ItemArgs{
+//				Vault:    pulumi.Any(_var.Demo_vault),
+//				Title:    pulumi.String("Demo Password Recipe"),
+//				Category: pulumi.String("password"),
+//				PasswordRecipe: &ItemPasswordRecipeArgs{
+//					Length:  pulumi.Int(40),
+//					Symbols: pulumi.Bool(false),
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			_, err = onepassword.NewItem(ctx, "demoLogin", &onepassword.ItemArgs{
+//				Vault:    pulumi.Any(_var.Demo_vault),
+//				Title:    pulumi.String("Demo Terraform Login"),
+//				Category: pulumi.String("login"),
+//				Username: pulumi.String("test@example.com"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			_, err = onepassword.NewItem(ctx, "demoDb", &onepassword.ItemArgs{
+//				Vault:    pulumi.Any(_var.Demo_vault),
+//				Category: pulumi.String("database"),
+//				Type:     pulumi.String("mysql"),
+//				Title:    pulumi.String("Demo TF Database"),
+//				Username: pulumi.String("root"),
+//				Database: pulumi.String("Example MySQL Instance"),
+//				Hostname: pulumi.String("localhost"),
+//				Port:     pulumi.String("3306"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 //
 // ## Import
@@ -70,7 +73,9 @@ import (
 // # import an existing 1Password item
 //
 // ```sh
-//  $ pulumi import onepassword:index/item:Item myitem vaults/<vault uuid>/items/<item uuid>
+//
+//	$ pulumi import onepassword:index/item:Item myitem vaults/<vault uuid>/items/<item uuid>
+//
 // ```
 type Item struct {
 	pulumi.CustomResourceState
@@ -295,7 +300,7 @@ func (i *Item) ToItemOutputWithContext(ctx context.Context) ItemOutput {
 // ItemArrayInput is an input type that accepts ItemArray and ItemArrayOutput values.
 // You can construct a concrete instance of `ItemArrayInput` via:
 //
-//          ItemArray{ ItemArgs{...} }
+//	ItemArray{ ItemArgs{...} }
 type ItemArrayInput interface {
 	pulumi.Input
 
@@ -320,7 +325,7 @@ func (i ItemArray) ToItemArrayOutputWithContext(ctx context.Context) ItemArrayOu
 // ItemMapInput is an input type that accepts ItemMap and ItemMapOutput values.
 // You can construct a concrete instance of `ItemMapInput` via:
 //
-//          ItemMap{ "key": ItemArgs{...} }
+//	ItemMap{ "key": ItemArgs{...} }
 type ItemMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/onepassword/pulumi-plugin.json
+++ b/sdk/go/onepassword/pulumi-plugin.json
@@ -1,5 +1,5 @@
 {
   "resource": true,
   "name": "onepassword",
-  "server": "https://github.com/SimCubeLtd/pulumi-onepassword/releases/download/v${VERSION}"
+  "server": "github://api.github.com/SimCubeLtd"
 }

--- a/sdk/go/onepassword/pulumiTypes.go
+++ b/sdk/go/onepassword/pulumiTypes.go
@@ -19,7 +19,7 @@ type GetItemSection struct {
 // GetItemSectionInput is an input type that accepts GetItemSectionArgs and GetItemSectionOutput values.
 // You can construct a concrete instance of `GetItemSectionInput` via:
 //
-//          GetItemSectionArgs{...}
+//	GetItemSectionArgs{...}
 type GetItemSectionInput interface {
 	pulumi.Input
 
@@ -48,7 +48,7 @@ func (i GetItemSectionArgs) ToGetItemSectionOutputWithContext(ctx context.Contex
 // GetItemSectionArrayInput is an input type that accepts GetItemSectionArray and GetItemSectionArrayOutput values.
 // You can construct a concrete instance of `GetItemSectionArrayInput` via:
 //
-//          GetItemSectionArray{ GetItemSectionArgs{...} }
+//	GetItemSectionArray{ GetItemSectionArgs{...} }
 type GetItemSectionArrayInput interface {
 	pulumi.Input
 
@@ -128,7 +128,7 @@ type GetItemSectionField struct {
 // GetItemSectionFieldInput is an input type that accepts GetItemSectionFieldArgs and GetItemSectionFieldOutput values.
 // You can construct a concrete instance of `GetItemSectionFieldInput` via:
 //
-//          GetItemSectionFieldArgs{...}
+//	GetItemSectionFieldArgs{...}
 type GetItemSectionFieldInput interface {
 	pulumi.Input
 
@@ -160,7 +160,7 @@ func (i GetItemSectionFieldArgs) ToGetItemSectionFieldOutputWithContext(ctx cont
 // GetItemSectionFieldArrayInput is an input type that accepts GetItemSectionFieldArray and GetItemSectionFieldArrayOutput values.
 // You can construct a concrete instance of `GetItemSectionFieldArrayInput` via:
 //
-//          GetItemSectionFieldArray{ GetItemSectionFieldArgs{...} }
+//	GetItemSectionFieldArray{ GetItemSectionFieldArgs{...} }
 type GetItemSectionFieldArrayInput interface {
 	pulumi.Input
 
@@ -251,7 +251,7 @@ type ItemPasswordRecipe struct {
 // ItemPasswordRecipeInput is an input type that accepts ItemPasswordRecipeArgs and ItemPasswordRecipeOutput values.
 // You can construct a concrete instance of `ItemPasswordRecipeInput` via:
 //
-//          ItemPasswordRecipeArgs{...}
+//	ItemPasswordRecipeArgs{...}
 type ItemPasswordRecipeInput interface {
 	pulumi.Input
 
@@ -293,11 +293,11 @@ func (i ItemPasswordRecipeArgs) ToItemPasswordRecipePtrOutputWithContext(ctx con
 // ItemPasswordRecipePtrInput is an input type that accepts ItemPasswordRecipeArgs, ItemPasswordRecipePtr and ItemPasswordRecipePtrOutput values.
 // You can construct a concrete instance of `ItemPasswordRecipePtrInput` via:
 //
-//          ItemPasswordRecipeArgs{...}
+//	        ItemPasswordRecipeArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type ItemPasswordRecipePtrInput interface {
 	pulumi.Input
 
@@ -443,7 +443,7 @@ type ItemSection struct {
 // ItemSectionInput is an input type that accepts ItemSectionArgs and ItemSectionOutput values.
 // You can construct a concrete instance of `ItemSectionInput` via:
 //
-//          ItemSectionArgs{...}
+//	ItemSectionArgs{...}
 type ItemSectionInput interface {
 	pulumi.Input
 
@@ -475,7 +475,7 @@ func (i ItemSectionArgs) ToItemSectionOutputWithContext(ctx context.Context) Ite
 // ItemSectionArrayInput is an input type that accepts ItemSectionArray and ItemSectionArrayOutput values.
 // You can construct a concrete instance of `ItemSectionArrayInput` via:
 //
-//          ItemSectionArray{ ItemSectionArgs{...} }
+//	ItemSectionArray{ ItemSectionArgs{...} }
 type ItemSectionArrayInput interface {
 	pulumi.Input
 
@@ -560,7 +560,7 @@ type ItemSectionField struct {
 // ItemSectionFieldInput is an input type that accepts ItemSectionFieldArgs and ItemSectionFieldOutput values.
 // You can construct a concrete instance of `ItemSectionFieldInput` via:
 //
-//          ItemSectionFieldArgs{...}
+//	ItemSectionFieldArgs{...}
 type ItemSectionFieldInput interface {
 	pulumi.Input
 
@@ -594,7 +594,7 @@ func (i ItemSectionFieldArgs) ToItemSectionFieldOutputWithContext(ctx context.Co
 // ItemSectionFieldArrayInput is an input type that accepts ItemSectionFieldArray and ItemSectionFieldArrayOutput values.
 // You can construct a concrete instance of `ItemSectionFieldArrayInput` via:
 //
-//          ItemSectionFieldArray{ ItemSectionFieldArgs{...} }
+//	ItemSectionFieldArray{ ItemSectionFieldArgs{...} }
 type ItemSectionFieldArrayInput interface {
 	pulumi.Input
 
@@ -690,7 +690,7 @@ type ItemSectionFieldPasswordRecipe struct {
 // ItemSectionFieldPasswordRecipeInput is an input type that accepts ItemSectionFieldPasswordRecipeArgs and ItemSectionFieldPasswordRecipeOutput values.
 // You can construct a concrete instance of `ItemSectionFieldPasswordRecipeInput` via:
 //
-//          ItemSectionFieldPasswordRecipeArgs{...}
+//	ItemSectionFieldPasswordRecipeArgs{...}
 type ItemSectionFieldPasswordRecipeInput interface {
 	pulumi.Input
 
@@ -732,11 +732,11 @@ func (i ItemSectionFieldPasswordRecipeArgs) ToItemSectionFieldPasswordRecipePtrO
 // ItemSectionFieldPasswordRecipePtrInput is an input type that accepts ItemSectionFieldPasswordRecipeArgs, ItemSectionFieldPasswordRecipePtr and ItemSectionFieldPasswordRecipePtrOutput values.
 // You can construct a concrete instance of `ItemSectionFieldPasswordRecipePtrInput` via:
 //
-//          ItemSectionFieldPasswordRecipeArgs{...}
+//	        ItemSectionFieldPasswordRecipeArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type ItemSectionFieldPasswordRecipePtrInput interface {
 	pulumi.Input
 

--- a/sdk/go/onepassword/pulumiUtilities.go
+++ b/sdk/go/onepassword/pulumiUtilities.go
@@ -88,14 +88,14 @@ func isZero(v interface{}) bool {
 
 // pkgResourceDefaultOpts provides package level defaults to pulumi.OptionResource.
 func pkgResourceDefaultOpts(opts []pulumi.ResourceOption) []pulumi.ResourceOption {
-	defaults := []pulumi.ResourceOption{pulumi.PluginDownloadURL("https://github.com/SimCubeLtd/pulumi-onepassword/releases/download/v${VERSION}")}
+	defaults := []pulumi.ResourceOption{pulumi.PluginDownloadURL("github://api.github.com/SimCubeLtd")}
 
 	return append(defaults, opts...)
 }
 
 // pkgInvokeDefaultOpts provides package level defaults to pulumi.OptionInvoke.
 func pkgInvokeDefaultOpts(opts []pulumi.InvokeOption) []pulumi.InvokeOption {
-	defaults := []pulumi.InvokeOption{pulumi.PluginDownloadURL("https://github.com/SimCubeLtd/pulumi-onepassword/releases/download/v${VERSION}")}
+	defaults := []pulumi.InvokeOption{pulumi.PluginDownloadURL("github://api.github.com/SimCubeLtd")}
 
 	return append(defaults, opts...)
 }

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -24,6 +24,6 @@
     },
     "pulumi": {
         "resource": true,
-        "pluginDownloadURL": "https://github.com/SimCubeLtd/pulumi-onepassword/releases/download/v${VERSION}"
+        "pluginDownloadURL": "github://api.github.com/SimCubeLtd"
     }
 }

--- a/sdk/nodejs/scripts/install-pulumi-plugin.js
+++ b/sdk/nodejs/scripts/install-pulumi-plugin.js
@@ -7,7 +7,7 @@ if (args.indexOf("${VERSION}") !== -1) {
 	process.exit(0);
 }
 
-var res = childProcess.spawnSync("pulumi", ["plugin", "install", "--server", "https://github.com/SimCubeLtd/pulumi-onepassword/releases/download/v${VERSION}"].concat(args), {
+var res = childProcess.spawnSync("pulumi", ["plugin", "install", "--server", "github://api.github.com/SimCubeLtd"].concat(args), {
     stdio: ["ignore", "inherit", "inherit"]
 });
 

--- a/sdk/nodejs/utilities.ts
+++ b/sdk/nodejs/utilities.ts
@@ -50,5 +50,5 @@ export function getVersion(): string {
 
 /** @internal */
 export function resourceOptsDefaults(): any {
-    return { version: getVersion(), pluginDownloadURL: "https://github.com/SimCubeLtd/pulumi-onepassword/releases/download/v${VERSION}" };
+    return { version: getVersion(), pluginDownloadURL: "github://api.github.com/SimCubeLtd" };
 }

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -5,7 +5,7 @@ Based on the [1Password terraform provider](https://github.com/1Password/terrafo
 
 &nbsp;
 
-The 1Password resource provider for Pulumi lets you use 1Password resources in your Infrastructure as Code deployments.
+Use the 1Password Pulumi Provider to reference, create, or update items in your existing vaults using [1Password Secrets Automation](https://developer.1password.com/docs/connect/).
 
 
 ## Installing

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -15,7 +15,7 @@ class InstallPluginCommand(install):
     def run(self):
         install.run(self)
         try:
-            check_call(['pulumi', 'plugin', 'install', 'resource', 'onepassword', PLUGIN_VERSION, '--server', 'https://github.com/SimCubeLtd/pulumi-onepassword/releases/download/v${VERSION}'])
+            check_call(['pulumi', 'plugin', 'install', 'resource', 'onepassword', PLUGIN_VERSION, '--server', 'github://api.github.com/SimCubeLtd'])
         except OSError as error:
             if error.errno == errno.ENOENT:
                 print(f"""

--- a/sdk/python/simcubeltd_pulumi_onepassword/_utilities.py
+++ b/sdk/python/simcubeltd_pulumi_onepassword/_utilities.py
@@ -236,4 +236,4 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
     return (lambda _: lifted_func)
 
 def get_plugin_download_url():
-	return "https://github.com/SimCubeLtd/pulumi-onepassword/releases/download/v${VERSION}"
+	return "github://api.github.com/SimCubeLtd"

--- a/sdk/python/simcubeltd_pulumi_onepassword/pulumi-plugin.json
+++ b/sdk/python/simcubeltd_pulumi_onepassword/pulumi-plugin.json
@@ -1,5 +1,5 @@
 {
   "resource": true,
   "name": "onepassword",
-  "server": "https://github.com/SimCubeLtd/pulumi-onepassword/releases/download/v${VERSION}"
+  "server": "github://api.github.com/SimCubeLtd"
 }


### PR DESCRIPTION
At Pulumi, we added [support for the Github Releases API](https://www.pulumi.com/docs/guides/pulumi-packages/how-to-author/#support-for-github-releases) (rather than a regular https://github.com/... URL) to download the the plugin binaries. This is a more stable way of finding the right plugin binary.

I updated the `pluginDownloadUrl` and configured the `github:` protocol handler. I rebuilt the provider & SDKs for this new URL to be integrated into it.